### PR TITLE
only write "Positive dir" message if iprint>0

### DIFF
--- a/lbfgsb/lbfgsb.f
+++ b/lbfgsb/lbfgsb.f
@@ -3279,8 +3279,10 @@ c
  55   continue
       if ( dd_p .gt.zero ) then
          call dcopy( n, xp, 1, x, 1 )
-         write(6,*) ' Positive dir derivative in projection '
-         write(6,*) ' Using the backtracking step '
+         if (iprint .ge. 1) then
+            write(6,*) ' Positive dir derivative in projection '
+            write(6,*) ' Using the backtracking step '
+         endif
       else
          go to 911
       endif


### PR DESCRIPTION
As was mentioned in #3, sometimes unwanted messages are printed.
This is caused by a small mistake in the code of lbfsgb. 
Although this is an upstream library, the fix is really trivial and the library was not updated for ~5 years now.
I will also inform authors of the library, but I'm sure it will take a long time (if the change would be implemented after all).
