### PR TITLE
Fixing afbarnard/go-lbfgsb#4

### DIFF
--- a/lbfgsb.go
+++ b/lbfgsb.go
@@ -396,7 +396,7 @@ var callbackMutex sync.Mutex
 
 // registerCallback registers a new callback and returns its' index
 // (>=1).
-func registerCallback(objective interface{}) uint {
+func registerCallback(f interface{}) uint {
 	callbackMutex.Lock()
 	defer callbackMutex.Unlock()
 	// We always increment callbackIndex to have more or less
@@ -414,10 +414,10 @@ func registerCallback(objective interface{}) uint {
 		// have this kind of problem since all the objects are
 		// unregistered at the end of the function call.
 		if callbackIndex == startIndex {
-			panic("no more space in the map to store an object")
+			panic("no more space in the map to store a callback function")
 		}
 	}
-	callbackFunctions[callbackIndex] = objective
+	callbackFunctions[callbackIndex] = f
 	return callbackIndex
 }
 

--- a/lbfgsb.go
+++ b/lbfgsb.go
@@ -303,7 +303,7 @@ func (lbfgsb *Lbfgsb) Minimize(
 		doLogging_c = C.int(1) // true
 		loggerId = registerCallback(lbfgsb.logger)
 		defer unregisterCallback(loggerId)
-		logFunctionCallbackData_c = unsafe.Pointer(&loggerId)
+		logFunctionCallbackData_c = unsafe.Pointer(loggerId)
 	}
 
 	// Allocate arrays for return value

--- a/lbfgsb.go
+++ b/lbfgsb.go
@@ -294,7 +294,6 @@ func (lbfgsb *Lbfgsb) Minimize(
 
 	// Set up callbacks for function, gradient, and logging
 	cId := registerCallback(objective)
-	println(cId)
 	callbackData_c := unsafe.Pointer(&cId)
 	var doLogging_c C.int                        // false
 	var logFunctionCallbackData_c unsafe.Pointer // null

--- a/lbfgsb.go
+++ b/lbfgsb.go
@@ -294,6 +294,7 @@ func (lbfgsb *Lbfgsb) Minimize(
 
 	// Set up callbacks for function, gradient, and logging
 	cId := registerCallback(objective)
+	defer unregisterCallback(cId)
 	callbackData_c := unsafe.Pointer(&cId)
 	var doLogging_c C.int                        // false
 	var logFunctionCallbackData_c unsafe.Pointer // null
@@ -301,6 +302,7 @@ func (lbfgsb *Lbfgsb) Minimize(
 	if lbfgsb.logger != nil {
 		doLogging_c = C.int(1) // true
 		loggerId = registerCallback(lbfgsb.logger)
+		defer unregisterCallback(loggerId)
 		logFunctionCallbackData_c = unsafe.Pointer(&loggerId)
 	}
 
@@ -356,11 +358,6 @@ func (lbfgsb *Lbfgsb) Minimize(
 	// Number of function and gradient evaluations is always the same
 	lbfgsb.statistics.GradientEvaluations = lbfgsb.statistics.FunctionEvaluations
 
-	// Unregister callbacks
-	unregisterCallback(cId)
-	if loggerId > 0 {
-		unregisterCallback(loggerId)
-	}
 	return
 }
 


### PR DESCRIPTION
Hi, I have created a pull request fixing #4. I testes it in go v1.7.1.

Since Go v1.6 Go code may pass a Go pointer to C provided that the Go
memory to which it points does not contain any Go pointers. I create a
synchronized map which stores all the go-objects we need to be able to
retrive. registerCallback is used to register a new object and return
its' index, lookupCallback returns the object by its' index,
unregisterCallback unregisters an object from the map
(callbackFunctions). Now instead of passing pointers to struct with a
pointer, we pass a pointer to int which identifies the apropriate
structure. Type assertion is used to convert interface{} to an actual
object. We do this in order to have unified code for passing objective
function callbacks and log function callbacks.
